### PR TITLE
Fixed some big bugs on the behavior of Group Violations

### DIFF
--- a/SIF.Visualization.Excel/Core/GroupViolation.cs
+++ b/SIF.Visualization.Excel/Core/GroupViolation.cs
@@ -213,6 +213,32 @@ namespace SIF.Visualization.Excel.Core
             return element;
         }
 
+        protected override void HandleNewState(Violation.ViolationType type)
+        {
+            if (!load)
+            {
+                switch (type)
+                {
+                    case ViolationType.NEW:
+                        DataModel.Instance.CurrentWorkbook.Violations.Add(this);
+                        break;
+                    case ViolationType.FALSEPOSITIVE:
+                        this.IsRead = true;
+                        DataModel.Instance.CurrentWorkbook.FalsePositives.Add(this);
+                        break;
+                    case ViolationType.LATER:
+                        this.IsRead = true;
+                        DataModel.Instance.CurrentWorkbook.LaterViolations.Add(this);
+                        break;
+                    case ViolationType.SOLVED:
+                        this.IsRead = false;
+                        DataModel.Instance.CurrentWorkbook.SolvedViolations.Add(this);
+                        break;
+                }
+                this.Violations.ToList().ForEach(vi => vi.ViolationState = type);
+            }
+        }
+
         #endregion
     }
 }

--- a/SIF.Visualization.Excel/Core/SingleViolation.cs
+++ b/SIF.Visualization.Excel/Core/SingleViolation.cs
@@ -35,10 +35,7 @@ namespace SIF.Visualization.Excel.Core
                     if (this.Control != null && value)
                     {
                         this.Control.BringToFront();
-                        if (!this.groupedViolation)
-                        {
-                            this.IsRead = true;
-                        }
+                        this.IsRead = true;
                     }
                 }
             }
@@ -233,6 +230,31 @@ namespace SIF.Visualization.Excel.Core
             element.SetAttributeValue(XName.Get("controlname"), this.controlName);
             element.SetAttributeValue(XName.Get("groupedviolation"), this.groupedViolation);
             return element;
+        }
+
+        protected override void HandleNewState(Violation.ViolationType type)
+        {
+            if (!load && !groupedViolation)
+            {
+                switch (type)
+                {
+                    case ViolationType.NEW:
+                        DataModel.Instance.CurrentWorkbook.Violations.Add(this);
+                        break;
+                    case ViolationType.FALSEPOSITIVE:
+                        this.IsRead = true;
+                        DataModel.Instance.CurrentWorkbook.FalsePositives.Add(this);
+                        break;
+                    case ViolationType.LATER:
+                        this.IsRead = true;
+                        DataModel.Instance.CurrentWorkbook.LaterViolations.Add(this);
+                        break;
+                    case ViolationType.SOLVED:
+                        this.IsRead = false;
+                        DataModel.Instance.CurrentWorkbook.SolvedViolations.Add(this);
+                        break;
+                }
+            }
         }
 
         #endregion

--- a/SIF.Visualization.Excel/Core/Violation.cs
+++ b/SIF.Visualization.Excel/Core/Violation.cs
@@ -316,30 +316,7 @@ namespace SIF.Visualization.Excel.Core
         /// Handles the action when a new ViolationState is set
         /// </summary>
         /// <param name="type">the type of the new violation State</param>
-        private void HandleNewState(ViolationType type)
-        {
-            if (!load)
-            {
-                switch (type)
-                {
-                    case ViolationType.NEW:
-                        DataModel.Instance.CurrentWorkbook.Violations.Add(this);
-                        break;
-                    case ViolationType.FALSEPOSITIVE:
-                        DataModel.Instance.CurrentWorkbook.FalsePositives.Add(this);
-                        this.IsRead = true;
-                        break;
-                    case ViolationType.LATER:
-                        DataModel.Instance.CurrentWorkbook.LaterViolations.Add(this);
-                        this.IsRead = true;
-                        break;
-                    case ViolationType.SOLVED:
-                        DataModel.Instance.CurrentWorkbook.SolvedViolations.Add(this);
-                        this.IsRead = false;
-                        break;
-                }
-            }
-        }
+        protected abstract void HandleNewState(ViolationType type);
 
         /// <summary>
         /// Handles the action when a ol ViolationState is removed

--- a/SIF.Visualization.Excel/FalsePositiveView/FalsePositiveView.xaml
+++ b/SIF.Visualization.Excel/FalsePositiveView/FalsePositiveView.xaml
@@ -35,7 +35,7 @@
             <Setter Property="Padding" Value="0"/>
             <Setter Property="BorderBrush" Value="Gray"/>
             <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Margin" Value="0 2 5 2"/>
+            <Setter Property="Margin" Value="0 0 0 0"/>
         </Style>
 
         <!--Style for the expander for the grouped violations-->
@@ -474,8 +474,17 @@
                                                     <ColumnDefinition Width="Auto"/>
                                                     <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
-                                                <Image x:Name="typeimage" Source="{Binding Rule.Type, Converter={StaticResource TypeToImageConverter}}" Grid.Column="0" Grid.Row="0" Margin="0 0 5 5" Height="25"
-                                                    Width="25" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+                                                <Image x:Name="typeimage" Grid.Column="0" Grid.Row="0" Margin="0 0 5 5" Height="25"
+                                                    Width="25" VerticalAlignment="Center" HorizontalAlignment="Left">
+                                                    <Image.Source>
+                                                        <MultiBinding Converter="{StaticResource TypeReadToImageConverter}">
+                                                            <MultiBinding.Bindings>
+                                                                <Binding Path="Rule.Type" />
+                                                                <Binding Path="IsRead" />
+                                                            </MultiBinding.Bindings>
+                                                        </MultiBinding>
+                                                    </Image.Source>
+                                                </Image>
                                                 <TextBlock Text="{Binding Rule.Name}" Grid.Column="1" Grid.Row="0"  Margin="10 0 5 5" FontSize="16" TextWrapping="Wrap"/>
                                             </Grid>
                                             <TextBlock Text="{Binding Severity}" Grid.Column="1" FontWeight="Bold" FontSize="16" Grid.Row="0" HorizontalAlignment="Right" Margin="10 1 0 5" Padding="4 0 2 2">

--- a/SIF.Visualization.Excel/LaterView/LaterView.xaml
+++ b/SIF.Visualization.Excel/LaterView/LaterView.xaml
@@ -35,7 +35,7 @@
             <Setter Property="Padding" Value="0"/>
             <Setter Property="BorderBrush" Value="Gray"/>
             <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Margin" Value="0 2 5 2"/>
+            <Setter Property="Margin" Value="0 0 0 0"/>
         </Style>
 
         <!--Style for the expander for the grouped violations-->
@@ -474,8 +474,17 @@
                                                     <ColumnDefinition Width="Auto"/>
                                                     <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
-                                                <Image x:Name="typeimage" Source="{Binding Rule.Type, Converter={StaticResource TypeToImageConverter}}" Grid.Column="0" Grid.Row="0" Margin="0 0 5 5" Height="25"
-                                                    Width="25" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+                                                <Image x:Name="typeimage" Grid.Column="0" Grid.Row="0" Margin="0 0 5 5" Height="25"
+                                                    Width="25" VerticalAlignment="Center" HorizontalAlignment="Left">
+                                                    <Image.Source>
+                                                        <MultiBinding Converter="{StaticResource TypeReadToImageConverter}">
+                                                            <MultiBinding.Bindings>
+                                                                <Binding Path="Rule.Type" />
+                                                                <Binding Path="IsRead" />
+                                                            </MultiBinding.Bindings>
+                                                        </MultiBinding>
+                                                    </Image.Source>
+                                                </Image>
                                                 <TextBlock Text="{Binding Rule.Name}" Grid.Column="1" Grid.Row="0"  Margin="10 0 5 5" FontSize="16" TextWrapping="Wrap"/>
                                             </Grid>
                                             <TextBlock Text="{Binding Severity}" Grid.Column="1" FontWeight="Bold" FontSize="16" Grid.Row="0" HorizontalAlignment="Right" Margin="10 1 0 5" Padding="4 0 2 2">

--- a/SIF.Visualization.Excel/SolvedView/SolvedView.xaml
+++ b/SIF.Visualization.Excel/SolvedView/SolvedView.xaml
@@ -35,7 +35,7 @@
             <Setter Property="Padding" Value="0"/>
             <Setter Property="BorderBrush" Value="Gray"/>
             <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Margin" Value="0 2 5 2"/>
+            <Setter Property="Margin" Value="0 0 0 0"/>
         </Style>
 
         <!--Style for the expander for the grouped violations-->
@@ -481,8 +481,17 @@
                                                     <ColumnDefinition Width="Auto"/>
                                                     <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
-                                                <Image x:Name="typeimage" Source="{Binding Rule.Type, Converter={StaticResource TypeToImageConverter}}" Grid.Column="0" Grid.Row="0" Margin="0 0 5 5" Height="25"
-                                                    Width="25" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+                                                <Image x:Name="typeimage" Grid.Column="0" Grid.Row="0" Margin="0 0 5 5" Height="25"
+                                                    Width="25" VerticalAlignment="Center" HorizontalAlignment="Left">
+                                                    <Image.Source>
+                                                        <MultiBinding Converter="{StaticResource TypeReadToImageConverter}">
+                                                            <MultiBinding.Bindings>
+                                                                <Binding Path="Rule.Type" />
+                                                                <Binding Path="IsRead" />
+                                                            </MultiBinding.Bindings>
+                                                        </MultiBinding>
+                                                    </Image.Source>
+                                                </Image>
                                                 <TextBlock Text="{Binding Rule.Name}" Grid.Column="1" Grid.Row="0"  Margin="10 0 5 5" FontSize="16" TextWrapping="Wrap"/>
                                             </Grid>
                                             <TextBlock Text="{Binding Severity}" Grid.Column="1" FontWeight="Bold" FontSize="16" Grid.Row="0" HorizontalAlignment="Right" Margin="10 1 0 5" Padding="4 0 2 2">

--- a/SIF.Visualization.Excel/ViolationsView/ViolationsView.xaml
+++ b/SIF.Visualization.Excel/ViolationsView/ViolationsView.xaml
@@ -36,7 +36,7 @@
             <Setter Property="Padding" Value="0"/>
             <Setter Property="BorderBrush" Value="Gray"/>
             <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Margin" Value="0 2 5 2"/>
+            <Setter Property="Margin" Value="0 0 0 0"/>
         </Style>
 
         <!--Style for the expander for the grouped violations-->
@@ -495,8 +495,17 @@
                                                     <ColumnDefinition Width="Auto"/>
                                                     <ColumnDefinition Width="*"/>
                                                 </Grid.ColumnDefinitions>
-                                                <Image x:Name="typeimage" Source="{Binding Rule.Type, Converter={StaticResource TypeToImageConverter}}" Grid.Column="0" Grid.Row="0" Margin="0 0 5 5" Height="25"
-                                                    Width="25" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+                                                <Image x:Name="typeimage" Grid.Column="0" Grid.Row="0" Margin="0 0 5 5" Height="25"
+                                                    Width="25" VerticalAlignment="Center" HorizontalAlignment="Left">
+                                                    <Image.Source>
+                                                        <MultiBinding Converter="{StaticResource TypeReadToImageConverter}">
+                                                            <MultiBinding.Bindings>
+                                                                <Binding Path="Rule.Type" />
+                                                                <Binding Path="IsRead" />
+                                                            </MultiBinding.Bindings>
+                                                        </MultiBinding>
+                                                    </Image.Source>
+                                                </Image>
                                                 <TextBlock Text="{Binding Rule.Name}" Grid.Column="1" Grid.Row="0"  Margin="10 0 5 5" FontSize="16" TextWrapping="Wrap"/>
                                             </Grid>
                                             <TextBlock Text="{Binding Severity}" Grid.Column="1" FontWeight="Bold" FontSize="16" Grid.Row="0" HorizontalAlignment="Right" Margin="10 1 0 5" Padding="4 0 2 2">


### PR DESCRIPTION
Fixed:
SIFEI terminates when a group violation is shown.
Grouped violations aren't marked as read when the Group Violation is read.
Grouped violations show colorized severity int the False Positive list.
